### PR TITLE
Introduce Inntekt model owned by API

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsInntektsGetter.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsInntektsGetter.kt
@@ -1,15 +1,21 @@
 package no.nav.dagpenger.inntekt
 
+import de.huxhorn.sulky.ulid.ULID
+import no.nav.dagpenger.inntekt.db.InntektId
 import no.nav.dagpenger.inntekt.db.InntektStore
 import no.nav.dagpenger.inntekt.db.StoredInntekt
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentRequest
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektskomponentClient
 import no.nav.dagpenger.inntekt.opptjeningsperiode.Opptjeningsperiode
+import java.time.LocalDateTime
 
-class BehandlingsInntektsGetter(private val inntektskomponentClient: InntektskomponentClient, private val inntektStore: InntektStore) {
+class BehandlingsInntektsGetter(
+    private val inntektskomponentClient: InntektskomponentClient,
+    private val inntektStore: InntektStore
+) {
+    private val ulidGenerator = ULID()
 
     suspend fun getBehandlingsInntekt(behandlingsKey: BehandlingsKey): StoredInntekt {
-
         val opptjeningsperiode = Opptjeningsperiode(behandlingsKey.beregningsDato)
 
         val inntektkomponentRequest = InntektkomponentRequest(
@@ -18,12 +24,36 @@ class BehandlingsInntektsGetter(private val inntektskomponentClient: Inntektskom
             opptjeningsperiode.sisteAvsluttendeKalenderMåned
         )
 
-        val storedInntekt = inntektStore.getInntektId(behandlingsKey)?.let { inntektStore.getInntekt(it) }
-            ?: inntektStore.insertInntekt(
-                behandlingsKey,
-                inntektskomponentClient.getInntekt(inntektkomponentRequest)
-            )
+        if (hasVedtakAssociation(behandlingsKey)) {
+            return getUnstoredInntekt(inntektkomponentRequest)
+        }
 
-        return storedInntekt
+        return isInntektStored(behandlingsKey)?.let { inntektStore.getInntekt(it) }
+            ?: fetchAndStoreInntekt(behandlingsKey, inntektkomponentRequest)
     }
+
+    private suspend fun fetchAndStoreInntekt(
+        behandlingsKey: BehandlingsKey,
+        inntektkomponentRequest: InntektkomponentRequest
+    ): StoredInntekt {
+        return inntektStore.insertInntekt(
+            behandlingsKey,
+            inntektskomponentClient.getInntekt(inntektkomponentRequest)
+        )
+    }
+
+    private fun isInntektStored(behandlingsKey: BehandlingsKey) =
+        inntektStore.getInntektId(behandlingsKey)
+
+    private suspend fun getUnstoredInntekt(inntektkomponentRequest: InntektkomponentRequest): StoredInntekt {
+        return StoredInntekt(
+            inntektId = InntektId(ulidGenerator.nextULID()),
+            inntekt = inntektskomponentClient.getInntekt(inntektkomponentRequest),
+            manueltRedigert = false,
+            timestamp = LocalDateTime.now()
+        )
+    }
+
+    private fun hasVedtakAssociation(behandlingsKey: BehandlingsKey) =
+        behandlingsKey.vedtakId == null
 }

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsKey.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsKey.kt
@@ -4,6 +4,6 @@ import java.time.LocalDate
 
 data class BehandlingsKey(
     val aktørId: String,
-    val vedtakId: Long,
+    val vedtakId: Long? = null,
     val beregningsDato: LocalDate
 )

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/mapping/MapToSpesifisertInntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/mapping/MapToSpesifisertInntekt.kt
@@ -7,13 +7,13 @@ import no.nav.dagpenger.events.inntekt.v1.InntektId
 import no.nav.dagpenger.events.inntekt.v1.Periode
 import no.nav.dagpenger.events.inntekt.v1.Postering
 import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
-import no.nav.dagpenger.inntekt.db.StoredInntekt
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.Aktoer
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.ArbeidsInntektMaaned
+import no.nav.dagpenger.inntekt.v1.models.Inntekt
 import java.time.LocalDateTime
 import java.time.YearMonth
 
-fun mapToSpesifisertInntekt(storedInntekt: StoredInntekt, sisteAvsluttendeKalenderMåned: YearMonth) =
+fun mapToSpesifisertInntekt(storedInntekt: Inntekt, sisteAvsluttendeKalenderMåned: YearMonth) =
     SpesifisertInntekt(
         inntektId = InntektId(storedInntekt.inntektId.id),
         ident = Aktør(

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/v1/SpesfisertInntektApi.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/v1/SpesfisertInntektApi.kt
@@ -8,8 +8,8 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import io.ktor.routing.route
-import no.nav.dagpenger.inntekt.BehandlingsKey
 import no.nav.dagpenger.inntekt.BehandlingsInntektsGetter
+import no.nav.dagpenger.inntekt.BehandlingsKey
 import no.nav.dagpenger.inntekt.mapping.mapToSpesifisertInntekt
 import no.nav.dagpenger.inntekt.opptjeningsperiode.Opptjeningsperiode
 import java.time.LocalDate
@@ -24,7 +24,8 @@ fun Route.spesifisertInntekt(behandlingsInntektsGetter: BehandlingsInntektsGette
                     BehandlingsKey(request.aktørId, request.vedtakId, request.beregningsDato)
                 )
 
-                val sisteAvsluttendeKalenderMåned = Opptjeningsperiode(request.beregningsDato).sisteAvsluttendeKalenderMåned
+                val sisteAvsluttendeKalenderMåned =
+                    Opptjeningsperiode(request.beregningsDato).sisteAvsluttendeKalenderMåned
 
                 val specifiedInntekt = mapToSpesifisertInntekt(storedInntekt, sisteAvsluttendeKalenderMåned)
 
@@ -36,6 +37,6 @@ fun Route.spesifisertInntekt(behandlingsInntektsGetter: BehandlingsInntektsGette
 
 data class SpesifisertInntektRequest(
     val aktørId: String,
-    val vedtakId: Long,
+    val vedtakId: Long? = null,
     val beregningsDato: LocalDate
 )

--- a/src/main/kotlin/no/nav/dagpenger/inntekt/v1/models/Inntekt.kt
+++ b/src/main/kotlin/no/nav/dagpenger/inntekt/v1/models/Inntekt.kt
@@ -1,0 +1,12 @@
+package no.nav.dagpenger.inntekt.v1.models
+
+import no.nav.dagpenger.inntekt.db.InntektId
+import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
+import java.time.LocalDateTime
+
+data class Inntekt(
+    val inntektId: InntektId,
+    val inntekt: InntektkomponentResponse,
+    val manueltRedigert: Boolean,
+    val timestamp: LocalDateTime? = null
+)

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/mapping/MapToSpesifisertInntektTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/mapping/MapToSpesifisertInntektTest.kt
@@ -6,7 +6,6 @@ import no.nav.dagpenger.events.inntekt.v1.InntektId
 import no.nav.dagpenger.events.inntekt.v1.Postering
 import no.nav.dagpenger.events.inntekt.v1.PosteringsType
 import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
-import no.nav.dagpenger.inntekt.db.StoredInntekt
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.Aktoer
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.AktoerType
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.ArbeidsInntektInformasjon
@@ -26,8 +25,9 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.YearMonth
 import kotlin.test.assertEquals
+import no.nav.dagpenger.inntekt.v1.models.Inntekt as ApiInntekt
 
-private val storedInntekt = StoredInntekt(
+private val storedInntekt = ApiInntekt(
     inntektId = no.nav.dagpenger.inntekt.db.InntektId("01DGCVFS44PT6B6ZGEYH2WXVMA"),
     inntekt = InntektkomponentResponse(
         listOf(

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/SpesifisertInntektApiSpec.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/SpesifisertInntektApiSpec.kt
@@ -14,10 +14,10 @@ import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.inntekt.AuthApiKeyVerifier
 import no.nav.dagpenger.inntekt.BehandlingsInntektsGetter
 import no.nav.dagpenger.inntekt.db.InntektId
-import no.nav.dagpenger.inntekt.db.StoredInntekt
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.Aktoer
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.AktoerType
 import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
+import no.nav.dagpenger.inntekt.v1.models.Inntekt
 import no.nav.dagpenger.ktor.auth.ApiKeyVerifier
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -57,7 +57,7 @@ class SpesifisertInntektApiSpec {
     private val inntektId = InntektId(ULID().nextULID())
     private val emptyInntekt = InntektkomponentResponse(emptyList(), Aktoer(AktoerType.AKTOER_ID, "1234"))
 
-    private val storedInntekt = StoredInntekt(
+    private val inntekt = Inntekt(
         inntektId,
         emptyInntekt,
         false
@@ -66,7 +66,7 @@ class SpesifisertInntektApiSpec {
     init {
         every {
             runBlocking { behandlingsInntektsGetterMock.getBehandlingsInntekt(any()) }
-        } returns storedInntekt
+        } returns inntekt
     }
 
     @Test

--- a/src/test/kotlin/no/nav/dagpenger/inntekt/v1/SpesifisertInntektApiSpec.kt
+++ b/src/test/kotlin/no/nav/dagpenger/inntekt/v1/SpesifisertInntektApiSpec.kt
@@ -33,6 +33,13 @@ class SpesifisertInntektApiSpec {
         }
         """.trimIndent()
 
+    val validJsonWithoutVedtak = """
+        {
+            "aktørId": "1234",
+            "beregningsDato": "2019-01-08"
+        }
+        """.trimIndent()
+
     val jsonMissingFields = """
         {
         	"aktørId": "1234",
@@ -75,6 +82,18 @@ class SpesifisertInntektApiSpec {
     }
 
     @Test
+    fun `Requests without vedtakId works, and does not store data`() = testApp {
+        handleRequest(HttpMethod.Post, spesifisertInntektPath) {
+            addHeader(HttpHeaders.ContentType, "application/json")
+            addHeader("X-API-KEY", apiKey)
+            setBody(validJsonWithoutVedtak)
+        }.apply {
+            assertTrue(requestHandled)
+            assertEquals(HttpStatusCode.OK, response.status())
+        }
+    }
+
+    @Test
     fun `Fails on post request with missing fields`() = testApp {
         handleRequest(HttpMethod.Post, spesifisertInntektPath) {
             addHeader(HttpHeaders.ContentType, "application/json")
@@ -87,9 +106,11 @@ class SpesifisertInntektApiSpec {
     }
 
     private fun testApp(callback: TestApplicationEngine.() -> Unit) {
-        withTestApplication(mockInntektApi(
-            behandlingsInntektsGetter = behandlingsInntektsGetterMock,
-            apiAuthApiKeyVerifier = authApiKeyVerifier
-        )) { callback() }
+        withTestApplication(
+            mockInntektApi(
+                behandlingsInntektsGetter = behandlingsInntektsGetterMock,
+                apiAuthApiKeyVerifier = authApiKeyVerifier
+            )
+        ) { callback() }
     }
 }


### PR DESCRIPTION
The API should own its own model. This introduces a data type for the API and maps StoredInntekt into the Inntekt defined by the API.