### PR TITLE
Hente inntekt basert på via http APIet som en erstatning til grpc.

### DIFF
--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsInntektsGetter.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsInntektsGetter.kt
@@ -16,8 +16,8 @@ private val LOGGER = KotlinLogging.logger {}
 
 class BehandlingsInntektsGetter(
     private val inntektskomponentClient: InntektskomponentClient,
-    private val inntektStore: InntektStore
-) {
+    private val inntektStore: InntektStore,
+) : InntektStore by inntektStore {
     suspend fun getKlassifisertInntekt(inntektparametre: Inntektparametre, callId: String? = null): Inntekt {
         return klassifiserOgMapInntekt(getSpesifisertInntekt(inntektparametre, callId))
     }
@@ -25,13 +25,13 @@ class BehandlingsInntektsGetter(
     suspend fun getSpesifisertInntekt(inntektparametre: Inntektparametre, callId: String? = null): SpesifisertInntekt {
         return mapToSpesifisertInntekt(
             getBehandlingsInntekt(inntektparametre, callId),
-            inntektparametre.opptjeningsperiode.sisteAvsluttendeKalenderMåned
+            inntektparametre.opptjeningsperiode.sisteAvsluttendeKalenderMåned,
         )
     }
 
     internal suspend fun getBehandlingsInntekt(
         inntektparametre: Inntektparametre,
-        callId: String? = null
+        callId: String? = null,
     ): StoredInntekt {
         return isInntektStored(inntektparametre)?.let {
             LOGGER.info { "Henter stored inntekt: ${inntektparametre.toDebugString()}" }
@@ -42,19 +42,19 @@ class BehandlingsInntektsGetter(
 
     private suspend fun fetchAndStoreInntekt(
         inntektparametre: Inntektparametre,
-        callId: String? = null
+        callId: String? = null,
     ): StoredInntekt {
         val inntektkomponentRequest = InntektkomponentRequest(
             aktørId = inntektparametre.aktørId,
             fødselsnummer = inntektparametre.fødselsnummer,
             månedFom = inntektparametre.opptjeningsperiode.førsteMåned,
-            månedTom = inntektparametre.opptjeningsperiode.sisteAvsluttendeKalenderMåned
+            månedTom = inntektparametre.opptjeningsperiode.sisteAvsluttendeKalenderMåned,
         )
         return inntektStore.storeInntekt(
             StoreInntektCommand(
                 inntektparametre = inntektparametre,
-                inntekt = inntektskomponentClient.getInntekt(inntektkomponentRequest, callId = callId)
-            )
+                inntekt = inntektskomponentClient.getInntekt(inntektkomponentRequest, callId = callId),
+            ),
         )
     }
 

--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsInntektsGetter.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/BehandlingsInntektsGetter.kt
@@ -3,6 +3,7 @@ package no.nav.dagpenger.inntekt
 import mu.KotlinLogging
 import no.nav.dagpenger.events.inntekt.v1.Inntekt
 import no.nav.dagpenger.events.inntekt.v1.SpesifisertInntekt
+import no.nav.dagpenger.inntekt.db.InntektId
 import no.nav.dagpenger.inntekt.db.InntektStore
 import no.nav.dagpenger.inntekt.db.Inntektparametre
 import no.nav.dagpenger.inntekt.db.StoreInntektCommand
@@ -17,9 +18,13 @@ private val LOGGER = KotlinLogging.logger {}
 class BehandlingsInntektsGetter(
     private val inntektskomponentClient: InntektskomponentClient,
     private val inntektStore: InntektStore,
-) : InntektStore by inntektStore {
+) {
     suspend fun getKlassifisertInntekt(inntektparametre: Inntektparametre, callId: String? = null): Inntekt {
         return klassifiserOgMapInntekt(getSpesifisertInntekt(inntektparametre, callId))
+    }
+
+    fun getKlassifisertInntekt(inntektId: InntektId): Inntekt {
+        return klassifiserOgMapInntekt(inntektStore.getSpesifisertInntekt(inntektId))
     }
 
     suspend fun getSpesifisertInntekt(inntektparametre: Inntektparametre, callId: String? = null): SpesifisertInntekt {

--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/KlassifisertInntekt.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/klassifiserer/KlassifisertInntekt.kt
@@ -19,7 +19,7 @@ fun klassifiserOgMapInntekt(spesifisertInntekt: SpesifisertInntekt): Inntekt {
         inntektsId = spesifisertInntekt.inntektId.id,
         inntektsListe = klassifisertInntektMåneder,
         manueltRedigert = spesifisertInntekt.manueltRedigert,
-        sisteAvsluttendeKalenderMåned = spesifisertInntekt.sisteAvsluttendeKalenderMåned
+        sisteAvsluttendeKalenderMåned = spesifisertInntekt.sisteAvsluttendeKalenderMåned,
     )
 }
 
@@ -33,7 +33,7 @@ private fun mapTilKlassifisertInntektMåneder(klassifisertePosteringer: List<Kla
 private fun mapTilKlassifisertInntektMåned(
     årmåned: YearMonth,
     klassifisertePosteringer: List<KlassifisertPostering>,
-    avvikMåneder: Map<YearMonth, List<Avvik>>
+    avvikMåneder: Map<YearMonth, List<Avvik>>,
 ) = KlassifisertInntektMåned(
     årMåned = årmåned,
     harAvvik = avvikMåneder.containsKey(årmåned),
@@ -42,7 +42,7 @@ private fun mapTilKlassifisertInntektMåned(
         .map { (klasse, klassifisertePosteringerForKlasse) ->
             KlassifisertInntekt(
                 beløp = klassifisertePosteringerForKlasse.fold(BigDecimal.ZERO) { sum, postering -> sum + postering.postering.beløp },
-                inntektKlasse = klasse
+                inntektKlasse = klasse,
             )
-        }
+        },
 )

--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/v1/InntektRoute.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/v1/InntektRoute.kt
@@ -2,17 +2,21 @@ package no.nav.dagpenger.inntekt.v1
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.plugins.MissingRequestParameterException
 import io.ktor.server.plugins.callid.callId
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 import no.nav.dagpenger.inntekt.BehandlingsInntektsGetter
+import no.nav.dagpenger.inntekt.db.InntektId
 import no.nav.dagpenger.inntekt.db.Inntektparametre
 import no.nav.dagpenger.inntekt.db.RegelKontekst
+import no.nav.dagpenger.inntekt.klassifiserer.klassifiserOgMapInntekt
 import no.nav.dagpenger.inntekt.oppslag.PersonOppslag
 import java.time.LocalDate
 
@@ -55,6 +59,13 @@ fun Route.inntekt(behandlingsInntektsGetter: BehandlingsInntektsGetter, personOp
                         call.callId
                     )
                 call.respond(HttpStatusCode.OK, klassifisertInntekt)
+            }
+        }
+        get("{inntektId}") {
+            withContext(IO) {
+                val inntektId = call.parameters["inntektId"]?.let { InntektId(it) } ?: throw MissingRequestParameterException("inntektId")
+                val inntekt = klassifiserOgMapInntekt(behandlingsInntektsGetter.getSpesifisertInntekt(inntektId = inntektId))
+                call.respond(HttpStatusCode.OK, inntekt)
             }
         }
     }

--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/v1/InntektRoute.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/v1/InntektRoute.kt
@@ -16,7 +16,6 @@ import no.nav.dagpenger.inntekt.BehandlingsInntektsGetter
 import no.nav.dagpenger.inntekt.db.InntektId
 import no.nav.dagpenger.inntekt.db.Inntektparametre
 import no.nav.dagpenger.inntekt.db.RegelKontekst
-import no.nav.dagpenger.inntekt.klassifiserer.klassifiserOgMapInntekt
 import no.nav.dagpenger.inntekt.oppslag.PersonOppslag
 import java.time.LocalDate
 
@@ -64,7 +63,7 @@ fun Route.inntekt(behandlingsInntektsGetter: BehandlingsInntektsGetter, personOp
         get("{inntektId}") {
             withContext(IO) {
                 val inntektId = call.parameters["inntektId"]?.let { InntektId(it) } ?: throw MissingRequestParameterException("inntektId")
-                val inntekt = klassifiserOgMapInntekt(behandlingsInntektsGetter.getSpesifisertInntekt(inntektId = inntektId))
+                val inntekt = behandlingsInntektsGetter.getKlassifisertInntekt(inntektId = inntektId)
                 call.respond(HttpStatusCode.OK, inntekt)
             }
         }

--- a/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/InntektRouteSpec.kt
+++ b/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/InntektRouteSpec.kt
@@ -330,6 +330,17 @@ internal class InntektRouteSpec {
         }
     }
 
+    @Test
+    fun `Hente klassifisert inntekt basert på inntekt ID`() = testApp {
+        handleAuthenticatedAzureAdRequest(HttpMethod.Get, "/v2/inntekt/klassifisert/${inntektId.id}") {
+        }.apply {
+            assertEquals(HttpStatusCode.OK, response.status())
+        }
+        handleAuthenticatedAzureAdRequest(HttpMethod.Get, "/v2/inntekt/klassifisert/1234") {
+        }.apply {
+            assertEquals(HttpStatusCode.BadRequest, response.status())
+        }
+    }
     private fun testApp(callback: TestApplicationEngine.() -> Unit) {
         withTestApplication(
             mockInntektApi(

--- a/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/InntektRouteSpec.kt
+++ b/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/InntektRouteSpec.kt
@@ -1,6 +1,12 @@
 package no.nav.dagpenger.inntekt.v1
 
 import de.huxhorn.sulky.ulid.ULID
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
@@ -13,10 +19,14 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
 import no.bekk.bekkopen.person.FodselsnummerCalculator.getFodselsnummerForDate
+import no.nav.dagpenger.events.inntekt.v1.InntektKlasse
+import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntekt
+import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntektMåned
 import no.nav.dagpenger.inntekt.ApiKeyVerifier
 import no.nav.dagpenger.inntekt.AuthApiKeyVerifier
 import no.nav.dagpenger.inntekt.BehandlingsInntektsGetter
 import no.nav.dagpenger.inntekt.db.InntektId
+import no.nav.dagpenger.inntekt.db.InntektNotFoundException
 import no.nav.dagpenger.inntekt.db.Inntektparametre
 import no.nav.dagpenger.inntekt.db.RegelKontekst
 import no.nav.dagpenger.inntekt.db.StoredInntekt
@@ -26,12 +36,16 @@ import no.nav.dagpenger.inntekt.inntektskomponenten.v1.InntektkomponentResponse
 import no.nav.dagpenger.inntekt.oppslag.Person
 import no.nav.dagpenger.inntekt.oppslag.PersonNotFoundException
 import no.nav.dagpenger.inntekt.oppslag.PersonOppslag
+import no.nav.dagpenger.inntekt.serder.jacksonObjectMapper
 import no.nav.dagpenger.inntekt.v1.TestApplication.handleAuthenticatedAzureAdRequest
 import no.nav.dagpenger.inntekt.v1.TestApplication.mockInntektApi
+import no.nav.dagpenger.inntekt.v1.TestApplication.testOAuthToken
+import no.nav.dagpenger.inntekt.v1.TestApplication.withMockAuthServerAndTestApplication
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import java.time.LocalDate
+import java.time.YearMonth
 import java.time.ZoneId
 import java.util.Date
 import kotlin.test.assertEquals
@@ -111,6 +125,24 @@ internal class InntektRouteSpec {
         }
         """.trimIndent()
 
+    val uKjentInntektsId = ULID().nextULID()
+    val kjentInntektsId = ULID().nextULID()
+    val kjentInntekt = no.nav.dagpenger.events.inntekt.v1.Inntekt(
+        kjentInntektsId,
+        sisteAvsluttendeKalenderMåned = YearMonth.of(2023, 10),
+        inntektsListe = listOf(
+            KlassifisertInntektMåned(
+                årMåned = YearMonth.of(2023, 10),
+                klassifiserteInntekter = listOf(
+                    KlassifisertInntekt(
+                        beløp = 1000.toBigDecimal(),
+                        inntektKlasse = InntektKlasse.ARBEIDSINNTEKT,
+                    ),
+                ),
+            ),
+        ),
+    )
+
     private val behandlingsInntektsGetterMock: BehandlingsInntektsGetter =
         spyk(BehandlingsInntektsGetter(mockk(relaxed = true), mockk(relaxed = true)))
 
@@ -151,6 +183,14 @@ internal class InntektRouteSpec {
         coEvery {
             behandlingsInntektsGetterMock.getBehandlingsInntekt(any(), any())
         } returns storedInntekt
+
+        coEvery {
+            behandlingsInntektsGetterMock.getKlassifisertInntekt(InntektId(kjentInntektsId))
+        } returns kjentInntekt
+
+        coEvery {
+            behandlingsInntektsGetterMock.getKlassifisertInntekt(InntektId(uKjentInntektsId))
+        } throws InntektNotFoundException("Inntekt not found")
     }
 
     @ParameterizedTest
@@ -331,16 +371,32 @@ internal class InntektRouteSpec {
     }
 
     @Test
-    fun `Hente klassifisert inntekt basert på inntekt ID`() = testApp {
-        handleAuthenticatedAzureAdRequest(HttpMethod.Get, "/v2/inntekt/klassifisert/${inntektId.id}") {
-        }.apply {
-            assertEquals(HttpStatusCode.OK, response.status())
+    fun `Hente klassifisert inntekt basert på inntekt ID`() = withMockAuthServerAndTestApplication(mockInntektApi(behandlingsInntektsGetter = behandlingsInntektsGetterMock)) {
+        val kjentInntektIdresponse = client.get("/v2/inntekt/klassifisert/$kjentInntektsId") {
+            autentisert()
         }
-        handleAuthenticatedAzureAdRequest(HttpMethod.Get, "/v2/inntekt/klassifisert/1234") {
-        }.apply {
-            assertEquals(HttpStatusCode.BadRequest, response.status())
+        assertEquals(HttpStatusCode.OK, kjentInntektIdresponse.status)
+        kjentInntektIdresponse.status shouldBe HttpStatusCode.OK
+        val hentetInntekt = jacksonObjectMapper.readValue(kjentInntektIdresponse.bodyAsText(), no.nav.dagpenger.events.inntekt.v1.Inntekt::class.java)
+        assertSoftly {
+            hentetInntekt.inntektsId shouldBe kjentInntekt.inntektsId
+            hentetInntekt.sisteAvsluttendeKalenderMåned shouldBe kjentInntekt.sisteAvsluttendeKalenderMåned
+            hentetInntekt.inntektsListe shouldBe kjentInntekt.inntektsListe
+            hentetInntekt.manueltRedigert shouldBe kjentInntekt.manueltRedigert
         }
+        val uKjentInntektIdresponse = client.get("/v2/inntekt/klassifisert/$uKjentInntektsId") {
+            autentisert()
+        }
+
+        uKjentInntektIdresponse.status shouldBe HttpStatusCode.NotFound
+
+        val ikkeInntektIdResponse = client.get("/v2/inntekt/klassifisert/123") {
+            autentisert()
+        }
+
+        ikkeInntektIdResponse.status shouldBe HttpStatusCode.BadRequest
     }
+
     private fun testApp(callback: TestApplicationEngine.() -> Unit) {
         withTestApplication(
             mockInntektApi(
@@ -349,5 +405,9 @@ internal class InntektRouteSpec {
                 apiAuthApiKeyVerifier = authApiKeyVerifier,
             ),
         ) { callback() }
+    }
+
+    private fun HttpRequestBuilder.autentisert() {
+        header(HttpHeaders.Authorization, "Bearer $testOAuthToken")
     }
 }

--- a/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/TestApplication.kt
+++ b/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/TestApplication.kt
@@ -9,7 +9,6 @@ import io.ktor.server.testing.TestApplicationCall
 import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.TestApplicationRequest
 import io.ktor.server.testing.handleRequest
-import io.ktor.server.testing.withTestApplication
 import io.mockk.mockk
 import io.prometheus.client.CollectorRegistry
 import no.nav.dagpenger.inntekt.AuthApiKeyVerifier
@@ -73,11 +72,6 @@ internal object TestApplication {
             )
         }
     }
-
-    internal fun <R> withMockAuthServerAndTestApplication(
-        moduleFunction: Application.() -> Unit,
-        test: TestApplicationEngine.() -> R,
-    ): R = withTestApplication(moduleFunction, test)
 
     internal fun TestApplicationEngine.handleAuthenticatedAzureAdRequest(
         method: HttpMethod,

--- a/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/TestApplication.kt
+++ b/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/v1/TestApplication.kt
@@ -5,10 +5,12 @@ import com.natpryce.konfig.ConfigurationMap
 import com.natpryce.konfig.overriding
 import io.ktor.http.HttpMethod
 import io.ktor.server.application.Application
+import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.TestApplicationCall
 import io.ktor.server.testing.TestApplicationEngine
 import io.ktor.server.testing.TestApplicationRequest
 import io.ktor.server.testing.handleRequest
+import io.ktor.server.testing.testApplication
 import io.mockk.mockk
 import io.prometheus.client.CollectorRegistry
 import no.nav.dagpenger.inntekt.AuthApiKeyVerifier
@@ -70,6 +72,16 @@ internal object TestApplication {
                 healthChecks = healthChecks,
                 collectorRegistry = CollectorRegistry(true),
             )
+        }
+    }
+
+    internal fun withMockAuthServerAndTestApplication(
+        moduleFunction: Application.() -> Unit = mockInntektApi(),
+        test: suspend ApplicationTestBuilder.() -> Unit,
+    ) {
+        return testApplication {
+            application(moduleFunction)
+            test()
         }
     }
 


### PR DESCRIPTION
Erstatning til [grpc](https://github.com/navikt/dp-inntekt/blob/master/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/rpc/InntektGrpcServer.kt) endepunktet. Det er kun https://github.com/navikt/dp-inntekt-klassifiserer som bruker grpc endepunktet. Det er litt for mange tannhjul og gir lite verdi å opprettholde det. 