### PR TITLE
Oppgrader til Gradle 9 og fjern bruk av ShadowJar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # Ignore everything
 **
 
-# Except shadow jar
-!dp-inntekt-api/build/libs/dp-inntekt-api-all.jar
+# Except distribution
+!dp-inntekt-api/build/install/**

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,8 +21,8 @@ jobs:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/wrapper-validation-action@v3.5.0
-      - uses: gradle/gradle-build-action@v3.5.0
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
         id: build
         env:
           DEPENDENCY_GRAPH_INCLUDE_CONFIGURATIONS: compileClasspath|runtimeClasspath
@@ -30,7 +30,8 @@ jobs:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
         with:
           dependency-graph: generate-and-submit
-          arguments: --configuration-cache build
+          cache-encryption-key: ${{ secrets.GradleEncryptionKey }}
+      - run: ./gradlew --configuration-cache build installDist
 
       - uses: nais/docker-build-push@v0
         name: docker-build-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM gcr.io/distroless/java21
 
 ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
 
-COPY dp-inntekt-api/build/libs/dp-inntekt-api-all.jar app.jar
+COPY dp-inntekt-api/build/install/dp-inntekt-api/lib /app/lib
 
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-cp", "/app/lib/*", "no.nav.dagpenger.inntekt.ApplicationKt"]

--- a/dp-inntekt-api/build.gradle.kts
+++ b/dp-inntekt-api/build.gradle.kts
@@ -1,11 +1,6 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
-
-
 plugins {
     id("common")
     application
-    alias(libs.plugins.shadow.jar)
     id("com.expediagroup.graphql") version "8.8.1"
     id("de.undercouch.download") version "5.6.0"
 }
@@ -89,10 +84,6 @@ dependencies {
     testImplementation("org.skyscreamer:jsonassert:1.5.3")
 }
 
-tasks.named("shadowJar") {
-    dependsOn("test")
-}
-
 tasks.named("compileKotlin") {
     dependsOn("graphqlGenerateClient")
 }
@@ -144,9 +135,4 @@ java {
     val mainJavaSourceSet: SourceDirectorySet = sourceSets.getByName("main").java
     val graphqlDir = "$buildDir_/generated/source/graphql/main"
     mainJavaSourceSet.srcDirs(graphqlDir)
-}
-
-tasks.withType<ShadowJar> {
-    transform(Log4j2PluginsCacheFileTransformer::class.java)
-    mergeServiceFiles()
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ plugins {
  */
 
 rootProject.name = "dp-inntekt"
-include("dp-inntekt-api", "dp-inntekt-kontrakter", "openapi")
+include("dp-inntekt-api", "dp-inntekt-kontrakter")
 
 dependencyResolutionManagement {
     repositories {


### PR DESCRIPTION
Har testet av Flyway-skript fortsatt migreres, dette er gjort i en commit som er droppet fra PRen (men tror uansett ikke problemet med Flyway som beskrevet i https://nav-it.slack.com/archives/CCP6QNBSN/p1755858810759339 oppstår før `dp-version-catalog` bumpes i #372, så det må vel testes en gang til.)