### PR TITLE
Håndter endringer fra Arena-brukere

### DIFF
--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/InntektApi.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/InntektApi.kt
@@ -13,6 +13,7 @@ import no.nav.dagpenger.inntekt.api.v1.enhetsregisteret
 import no.nav.dagpenger.inntekt.api.v1.inntekt
 import no.nav.dagpenger.inntekt.api.v1.opptjeningsperiodeApi
 import no.nav.dagpenger.inntekt.api.v1.uklassifisertInntekt
+import no.nav.dagpenger.inntekt.api.v3.inntektId
 import no.nav.dagpenger.inntekt.api.v3.inntektV3
 import no.nav.dagpenger.inntekt.db.InntektStore
 import no.nav.dagpenger.inntekt.dpbehandling.DpBehandlingKlient
@@ -60,6 +61,10 @@ internal fun Application.inntektApi(
         authenticate("azure") {
             route("/v3/inntekt") {
                 inntektV3(behandlingsInntektsGetter, personOppslag, inntektStore, inntektskomponentHttpClient)
+                inntektId(
+                    inntektStore = inntektStore,
+                    personOppslag = personOppslag,
+                )
             }
         }
     }

--- a/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/api/v3/InntektIdRoute.kt
+++ b/dp-inntekt-api/src/main/kotlin/no/nav/dagpenger/inntekt/api/v3/InntektIdRoute.kt
@@ -1,0 +1,53 @@
+package no.nav.dagpenger.inntekt.api.v3
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import no.nav.dagpenger.inntekt.db.InntektStore
+import no.nav.dagpenger.inntekt.db.Inntektparametre
+import no.nav.dagpenger.inntekt.db.RegelKontekst
+import no.nav.dagpenger.inntekt.oppslag.PersonOppslag
+import java.time.LocalDate
+
+private val logger = KotlinLogging.logger {}
+
+fun Route.inntektId(
+    inntektStore: InntektStore,
+    personOppslag: PersonOppslag,
+) {
+    authenticate("azure") {
+        route("/inntektId/{aktørId}/{kontekstType}/{kontekstId}/{beregningsDato}") {
+            get {
+                val aktørId = call.parameters["aktørId"]!!
+                val kontekstId = call.parameters["kontekstId"]!!
+                val kontekstType = call.parameters["kontekstType"]!!
+                val beregningsDato = LocalDate.parse(call.parameters["beregningsDato"]!!)
+                val person = personOppslag.hentPerson(aktørId)
+
+                logger.info {
+                    "Skal hente inntektId for " +
+                        "kontekstType=$kontekstType, " +
+                        "kontekstId=$kontekstId, " +
+                        "beregningsDato=$beregningsDato"
+                }
+
+                inntektStore
+                    .getInntektId(
+                        Inntektparametre(
+                            aktørId = person.aktørId,
+                            fødselsnummer = person.fødselsnummer,
+                            regelkontekst = RegelKontekst(kontekstId, kontekstType),
+                            beregningsdato = beregningsDato,
+                        ),
+                    )?.let {
+                        logger.info { "Fant inntektId ${it.id} for kontekstId $kontekstId" }
+                        call.respond(HttpStatusCode.OK, it.id)
+                    } ?: throw RuntimeException("Klarte ikke finne inntektId for Arena-parametere")
+            }
+        }
+    }
+}

--- a/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/api/v1/UklassifisertInntektRouteTest.kt
+++ b/dp-inntekt-api/src/test/kotlin/no/nav/dagpenger/inntekt/api/v1/UklassifisertInntektRouteTest.kt
@@ -519,7 +519,7 @@ internal class UklassifisertInntektRouteTest {
     }
 
     @Test
-    fun `Post request for uklassifisert inntekt med inntektId lagrer og returnerer ny ID, uten behandlingId og opplysningId`() =
+    fun `Post request for uklassifisert inntekt med inntektId lagrer og returnerer ny ID, uten å rekjøre i dp-behandling, når erArena er true`() =
 
         mockInntektApi(
             inntektskomponentClient = inntektskomponentClientMock,
@@ -550,7 +550,7 @@ internal class UklassifisertInntektRouteTest {
             val response =
                 it.autentisert(
                     httpMethod = HttpMethod.Post,
-                    endepunkt = "$uklassifisertInntekt/${inntektId.id}",
+                    endepunkt = "$uklassifisertInntekt/${inntektId.id}?erArena=true",
                     body = body,
                 )
 
@@ -572,6 +572,28 @@ internal class UklassifisertInntektRouteTest {
             storeInntektCommandSlot.captured.manueltRedigert!!.redigertAv shouldBe TEST_OAUTH_USER
             storeInntektCommandSlot.captured.manueltRedigert!!.begrunnelse shouldBe "Dette er en begrunnelse."
             verify(exactly = 0) { dpBehandlingKlient.rekjørBehandling(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun `Post request for uklassifisrt inntekt med inntektId gir 400 Bad Request uten behandlingId og opplysningId når erArena er false`() =
+        mockInntektApi(
+            inntektskomponentClient = inntektskomponentClientMock,
+            inntektStore = inntektStoreMock,
+            dpBehandlingKlient = dpBehandlingKlient,
+        ) {
+            val body =
+                UklassifisertInntektRouteTest::class.java
+                    .getResource("/test-data/expected-uklassifisert-post-body.json")
+                    ?.readText()
+
+            val response =
+                it.autentisert(
+                    httpMethod = HttpMethod.Post,
+                    endepunkt = "$uklassifisertInntekt/${inntektId.id}?erArena=false",
+                    body = body!!,
+                )
+
+            response.status shouldBe BadRequest
         }
 
     @Test


### PR DESCRIPTION
Legg til nytt endepunkt for å bytte ut "Arena-parameter" med inntektId, som brukes av frontend. 
Da kan vi bruke samme funksjonalitet i frontend enten man kommer fra Arena eller dp-sak. 
I den eksisterende inntektlagringen legger vi til et "erArena"-parameter, så vi ikke prøver å oppdatere dp-behandling når det er "Arena-endringer". Da kan vi også kaste feilmelding hvis erArena = false og det mangler opplysningId og/eller behandlingId. 
Vi gjenbruker det eksisterende endepunktet for å slippe å håndtere endringer flere steder, siden det kun er sending til dp-behandling som er ulikt. 
Ideelt sett burde vi refaktorert en del og flyttet kode ut i servicer o.l. men det kommer senere en gang.